### PR TITLE
[FEAT] Advanced color types

### DIFF
--- a/src/app/command/recolor.rs
+++ b/src/app/command/recolor.rs
@@ -1,19 +1,26 @@
-use crate::image::color::ColorInfo;
+use crate::image::color::{BitDepth, ColorInfo, ColorSpace};
 
 use anyhow::Result;
+
 use clap::Parser;
 use image::DynamicImage;
 
 #[derive(Parser, Debug)]
 pub struct RecolorArgs {
-    /// Color type
-    #[clap(short, long)]
-    color_type: ColorInfo,
+    /// Color space of the image
+    #[clap(short, long, value_enum)]
+    color_space: ColorSpace,
+
+    /// Bit depth of the image
+    #[clap(short = 'B', long, value_enum)]
+    bit_depth: BitDepth,
 }
 
 impl RecolorArgs {
     pub fn run(&self, image: &mut DynamicImage) -> Result<()> {
-        self.color_type.convert_image(image);
+        let color_info = ColorInfo::new(&self.color_space, &self.bit_depth);
+
+        color_info.convert_image(image);
         Ok(())
     }
 }

--- a/src/app/command/recolor.rs
+++ b/src/app/command/recolor.rs
@@ -12,7 +12,7 @@ pub struct RecolorArgs {
     color_space: ColorSpace,
 
     /// Bit depth of the image
-    #[clap(short = 'B', long, value_enum)]
+    #[clap(short, long, value_enum)]
     bit_depth: BitDepth,
 }
 

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -10,7 +10,7 @@ pub struct ColorInfo {
     pub color_type: ColorTypeExt,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum BitDepth {
     B8 = 8,
     B16 = 16,

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -114,7 +114,7 @@ impl ColorInfo {
     }
     pub fn convert_image(&self, image: &mut DynamicImage) {
         let color_space = self.to_color_type();
-        let colored_image = match color_space {
+        *image = match color_space {
             ColorType::L8 => DynamicImage::ImageLuma8(image.to_luma8()),
             ColorType::La8 => DynamicImage::ImageLumaA8(image.to_luma_alpha8()),
             ColorType::L16 => DynamicImage::ImageLuma16(image.to_luma16()),
@@ -127,7 +127,6 @@ impl ColorInfo {
             ColorType::Rgba32F => DynamicImage::ImageRgba32F(image.to_rgba32f()),
             _ => image.clone(),
         };
-        *image = colored_image;
     }
     fn to_color_type(&self) -> ColorType {
         match self.color_space {

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -27,12 +27,6 @@ impl Display for BitDepth {
     }
 }
 
-impl PartialEq for BitDepth {
-    fn eq(&self, other: &Self) -> bool {
-        self == other
-    }
-}
-
 impl FromStr for BitDepth {
     type Err = String;
 

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -113,7 +113,7 @@ impl ColorInfo {
         }
     }
     pub fn convert_image(&self, image: &mut DynamicImage) {
-        let color_space = self.to_color_space();
+        let color_space = self.to_color_type();
         let colored_image = match color_space {
             ColorType::L8 => DynamicImage::ImageLuma8(image.to_luma8()),
             ColorType::La8 => DynamicImage::ImageLumaA8(image.to_luma_alpha8()),
@@ -129,7 +129,7 @@ impl ColorInfo {
         };
         *image = colored_image;
     }
-    fn to_color_space(&self) -> ColorType {
+    fn to_color_type(&self) -> ColorType {
         match self.color_space {
             ColorSpace::Rgb => match self.bit_depth {
                 BitDepth::B8 => ColorType::Rgb8,

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -1,76 +1,125 @@
+use std::fmt::Display;
 use std::str::FromStr;
 
+use clap::ValueEnum;
 use image::{ColorType, DynamicImage};
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ColorInfo {
-    pub bit_depth: u32,
-    pub color_type: String,
-    pub is_alpha: bool,
+    pub bit_depth: BitDepth,
+    pub color_type: ColorTypeExt,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BitDepth {
+    B8 = 8,
+    B16 = 16,
+    B32 = 32,
+}
+
+impl Display for BitDepth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BitDepth::B8 => write!(f, "{}", 8),
+            BitDepth::B16 => write!(f, "{}", 16),
+            BitDepth::B32 => write!(f, "{}", 32),
+        }
+    }
+}
+
+impl PartialEq for BitDepth {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl FromStr for BitDepth {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let num: u32 = s.parse::<u32>().unwrap();
+
+        match num {
+            8 => Ok(BitDepth::B8),
+            16 => Ok(BitDepth::B16),
+            32 => Ok(BitDepth::B32),
+            _ => Err("Bit depth must be 8, 16 or 32.".into()),
+        }
+    }
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+pub enum ColorTypeExt {
+    Rgb,
+    RgbA,
+    Luma,
+    LumaA,
+    Unknown,
+}
+
+impl Display for ColorTypeExt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 impl ColorInfo {
+    pub fn new(color_type: ColorTypeExt, bit_depth: BitDepth) -> Self {
+        ColorInfo {
+            color_type,
+            bit_depth,
+        }
+    }
     pub fn from_image(image: &DynamicImage) -> Self {
         match image.color() {
             ColorType::L8 => ColorInfo {
-                bit_depth: 8,
-                color_type: "Luma".to_string(),
-                is_alpha: false,
+                bit_depth: BitDepth::B8,
+                color_type: ColorTypeExt::Luma,
             },
             ColorType::La8 => ColorInfo {
-                bit_depth: 8,
-                color_type: "Luma".to_string(),
-                is_alpha: true,
+                bit_depth: BitDepth::B8,
+                color_type: ColorTypeExt::LumaA,
             },
             ColorType::L16 => ColorInfo {
-                bit_depth: 16,
-                color_type: "Luma".to_string(),
-                is_alpha: true,
+                bit_depth: BitDepth::B16,
+                color_type: ColorTypeExt::Luma,
             },
             ColorType::La16 => ColorInfo {
-                bit_depth: 16,
-                color_type: "Luma".to_string(),
-                is_alpha: true,
+                bit_depth: BitDepth::B16,
+                color_type: ColorTypeExt::LumaA,
             },
             ColorType::Rgb8 => ColorInfo {
-                bit_depth: 8,
-                color_type: "RGB".to_string(),
-                is_alpha: false,
+                bit_depth: BitDepth::B8,
+                color_type: ColorTypeExt::Rgb,
             },
             ColorType::Rgba8 => ColorInfo {
-                bit_depth: 8,
-                color_type: "RGB".to_string(),
-                is_alpha: true,
+                bit_depth: BitDepth::B8,
+                color_type: ColorTypeExt::RgbA,
             },
             ColorType::Rgb16 => ColorInfo {
-                bit_depth: 16,
-                color_type: "RGB".to_string(),
-                is_alpha: false,
+                bit_depth: BitDepth::B16,
+                color_type: ColorTypeExt::Rgb,
             },
             ColorType::Rgba16 => ColorInfo {
-                bit_depth: 16,
-                color_type: "RGB".to_string(),
-                is_alpha: true,
+                bit_depth: BitDepth::B16,
+                color_type: ColorTypeExt::Rgb,
             },
             ColorType::Rgb32F => ColorInfo {
-                bit_depth: 32,
-                color_type: "RGB".to_string(),
-                is_alpha: false,
+                bit_depth: BitDepth::B32,
+                color_type: ColorTypeExt::Rgb,
             },
             ColorType::Rgba32F => ColorInfo {
-                bit_depth: 32,
-                color_type: "RGB".to_string(),
-                is_alpha: true,
+                bit_depth: BitDepth::B32,
+                color_type: ColorTypeExt::RgbA,
             },
             _ => ColorInfo {
-                bit_depth: 8,
-                color_type: "Unknown".to_string(),
-                is_alpha: false,
+                bit_depth: BitDepth::B8,
+                color_type: ColorTypeExt::Unknown,
             },
         }
     }
     pub fn convert_image(&self, image: &mut DynamicImage) {
-        let color_type = self.get_color_type();
+        let color_type = self.to_color_type();
         let colored_image = match color_type {
             ColorType::L8 => DynamicImage::ImageLuma8(image.to_luma8()),
             ColorType::La8 => DynamicImage::ImageLumaA8(image.to_luma_alpha8()),
@@ -86,82 +135,29 @@ impl ColorInfo {
         };
         *image = colored_image;
     }
-    fn get_color_type(&self) -> ColorType {
-        match self.color_type.as_str() {
-            "RGB" => match self.bit_depth {
-                8 => {
-                    if self.is_alpha {
-                        ColorType::Rgba8
-                    } else {
-                        ColorType::Rgb8
-                    }
-                }
-                16 => {
-                    if self.is_alpha {
-                        ColorType::Rgba16
-                    } else {
-                        ColorType::Rgb16
-                    }
-                }
-                32 => {
-                    if self.is_alpha {
-                        ColorType::Rgba32F
-                    } else {
-                        ColorType::Rgb32F
-                    }
-                }
-                _ => ColorType::Rgb8,
+    fn to_color_type(&self) -> ColorType {
+        match self.color_type {
+            ColorTypeExt::Rgb => match self.bit_depth {
+                BitDepth::B8 => ColorType::Rgb8,
+                BitDepth::B16 => ColorType::Rgb16,
+                BitDepth::B32 => ColorType::Rgb32F,
             },
-            "Luma" => match self.bit_depth {
-                8 => {
-                    if self.is_alpha {
-                        ColorType::La8
-                    } else {
-                        ColorType::L8
-                    }
-                }
-                16 => {
-                    if self.is_alpha {
-                        ColorType::La16
-                    } else {
-                        ColorType::L16
-                    }
-                }
-                _ => ColorType::L8,
+            ColorTypeExt::RgbA => match self.bit_depth {
+                BitDepth::B8 => ColorType::Rgba8,
+                BitDepth::B16 => ColorType::Rgba16,
+                BitDepth::B32 => ColorType::Rgba32F,
             },
-            _ => ColorType::Rgb8,
+            ColorTypeExt::Luma => match self.bit_depth {
+                BitDepth::B8 => ColorType::L8,
+                BitDepth::B16 => ColorType::L16,
+                BitDepth::B32 => ColorType::L16,
+            },
+            ColorTypeExt::LumaA => match self.bit_depth {
+                BitDepth::B8 => ColorType::La8,
+                BitDepth::B16 => ColorType::La16,
+                BitDepth::B32 => ColorType::La16,
+            },
+            ColorTypeExt::Unknown => ColorType::Rgb8,
         }
-    }
-}
-
-impl FromStr for ColorInfo {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let col_type = if s.to_lowercase().contains("luma") {
-            "Luma"
-        } else if s.to_lowercase().contains("rgb") {
-            "RGB"
-        } else {
-            return Err("Invalid color type".to_string());
-        };
-
-        let bit_depth = if s.contains("8") {
-            8
-        } else if s.contains("16") {
-            16
-        } else if s.contains("32") {
-            32
-        } else {
-            return Err("Invalid bit depth".to_string());
-        };
-
-        let is_alpha = s.to_lowercase().contains("alpha");
-
-        Ok(ColorInfo {
-            color_type: col_type.to_string(),
-            bit_depth,
-            is_alpha,
-        })
     }
 }

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -7,10 +7,10 @@ use image::{ColorType, DynamicImage};
 #[derive(Debug, Clone)]
 pub struct ColorInfo {
     pub bit_depth: BitDepth,
-    pub color_type: ColorTypeExt,
+    pub color_space: ColorSpace,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum BitDepth {
     B8 = 8,
     B16 = 16,
@@ -48,8 +48,8 @@ impl FromStr for BitDepth {
     }
 }
 
-#[derive(ValueEnum, Debug, Clone)]
-pub enum ColorTypeExt {
+#[derive(ValueEnum, Debug, Clone, Copy)]
+pub enum ColorSpace {
     Rgb,
     RgbA,
     Luma,
@@ -57,70 +57,70 @@ pub enum ColorTypeExt {
     Unknown,
 }
 
-impl Display for ColorTypeExt {
+impl Display for ColorSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
 impl ColorInfo {
-    pub fn new(color_type: ColorTypeExt, bit_depth: BitDepth) -> Self {
+    pub fn new(color_space: &ColorSpace, bit_depth: &BitDepth) -> Self {
         ColorInfo {
-            color_type,
-            bit_depth,
+            color_space: *color_space,
+            bit_depth: *bit_depth,
         }
     }
     pub fn from_image(image: &DynamicImage) -> Self {
         match image.color() {
             ColorType::L8 => ColorInfo {
                 bit_depth: BitDepth::B8,
-                color_type: ColorTypeExt::Luma,
+                color_space: ColorSpace::Luma,
             },
             ColorType::La8 => ColorInfo {
                 bit_depth: BitDepth::B8,
-                color_type: ColorTypeExt::LumaA,
+                color_space: ColorSpace::LumaA,
             },
             ColorType::L16 => ColorInfo {
                 bit_depth: BitDepth::B16,
-                color_type: ColorTypeExt::Luma,
+                color_space: ColorSpace::Luma,
             },
             ColorType::La16 => ColorInfo {
                 bit_depth: BitDepth::B16,
-                color_type: ColorTypeExt::LumaA,
+                color_space: ColorSpace::LumaA,
             },
             ColorType::Rgb8 => ColorInfo {
                 bit_depth: BitDepth::B8,
-                color_type: ColorTypeExt::Rgb,
+                color_space: ColorSpace::Rgb,
             },
             ColorType::Rgba8 => ColorInfo {
                 bit_depth: BitDepth::B8,
-                color_type: ColorTypeExt::RgbA,
+                color_space: ColorSpace::RgbA,
             },
             ColorType::Rgb16 => ColorInfo {
                 bit_depth: BitDepth::B16,
-                color_type: ColorTypeExt::Rgb,
+                color_space: ColorSpace::Rgb,
             },
             ColorType::Rgba16 => ColorInfo {
                 bit_depth: BitDepth::B16,
-                color_type: ColorTypeExt::Rgb,
+                color_space: ColorSpace::Rgb,
             },
             ColorType::Rgb32F => ColorInfo {
                 bit_depth: BitDepth::B32,
-                color_type: ColorTypeExt::Rgb,
+                color_space: ColorSpace::Rgb,
             },
             ColorType::Rgba32F => ColorInfo {
                 bit_depth: BitDepth::B32,
-                color_type: ColorTypeExt::RgbA,
+                color_space: ColorSpace::RgbA,
             },
             _ => ColorInfo {
                 bit_depth: BitDepth::B8,
-                color_type: ColorTypeExt::Unknown,
+                color_space: ColorSpace::Unknown,
             },
         }
     }
     pub fn convert_image(&self, image: &mut DynamicImage) {
-        let color_type = self.to_color_type();
-        let colored_image = match color_type {
+        let color_space = self.to_color_space();
+        let colored_image = match color_space {
             ColorType::L8 => DynamicImage::ImageLuma8(image.to_luma8()),
             ColorType::La8 => DynamicImage::ImageLumaA8(image.to_luma_alpha8()),
             ColorType::L16 => DynamicImage::ImageLuma16(image.to_luma16()),
@@ -135,29 +135,29 @@ impl ColorInfo {
         };
         *image = colored_image;
     }
-    fn to_color_type(&self) -> ColorType {
-        match self.color_type {
-            ColorTypeExt::Rgb => match self.bit_depth {
+    fn to_color_space(&self) -> ColorType {
+        match self.color_space {
+            ColorSpace::Rgb => match self.bit_depth {
                 BitDepth::B8 => ColorType::Rgb8,
                 BitDepth::B16 => ColorType::Rgb16,
                 BitDepth::B32 => ColorType::Rgb32F,
             },
-            ColorTypeExt::RgbA => match self.bit_depth {
+            ColorSpace::RgbA => match self.bit_depth {
                 BitDepth::B8 => ColorType::Rgba8,
                 BitDepth::B16 => ColorType::Rgba16,
                 BitDepth::B32 => ColorType::Rgba32F,
             },
-            ColorTypeExt::Luma => match self.bit_depth {
+            ColorSpace::Luma => match self.bit_depth {
                 BitDepth::B8 => ColorType::L8,
                 BitDepth::B16 => ColorType::L16,
                 BitDepth::B32 => ColorType::L16,
             },
-            ColorTypeExt::LumaA => match self.bit_depth {
+            ColorSpace::LumaA => match self.bit_depth {
                 BitDepth::B8 => ColorType::La8,
                 BitDepth::B16 => ColorType::La16,
                 BitDepth::B32 => ColorType::La16,
             },
-            ColorTypeExt::Unknown => ColorType::Rgb8,
+            ColorSpace::Unknown => ColorType::Rgb8,
         }
     }
 }

--- a/src/image/info.rs
+++ b/src/image/info.rs
@@ -21,6 +21,5 @@ pub fn print_info(image: &DynamicImage, path: PathBuf, do_short: bool) {
     if !do_short {
         println!("Color space: {}", color_info.color_type);
         println!("Bit depth: {}", color_info.bit_depth);
-        println!("Alpha: {}", color_info.is_alpha);
     }
 }

--- a/src/image/info.rs
+++ b/src/image/info.rs
@@ -19,7 +19,7 @@ pub fn print_info(image: &DynamicImage, path: PathBuf, do_short: bool) {
     println!("Format: {}", format.to_mime_type());
 
     if !do_short {
-        println!("Color space: {}", color_info.color_type);
+        println!("Color space: {}", color_info.color_space);
         println!("Bit depth: {}", color_info.bit_depth);
     }
 }

--- a/src/image/manipulator.rs
+++ b/src/image/manipulator.rs
@@ -107,31 +107,38 @@ pub fn resize_image(
 }
 
 pub fn remove_background(image: &mut DynamicImage) {
+    use super::color::BitDepth::{B16, B32, B8};
     let color_info = ColorInfo::from_image(image);
 
-    if color_info.bit_depth == 8 {
-        let mut image8bit = image.to_rgba8();
-        for p in image8bit.pixels_mut() {
-            if p[0] == 255 && p[1] == 255 && p[2] == 255 {
-                p[3] = 0;
+    match color_info.bit_depth {
+        B8 => {
+            let mut image8bit = image.to_rgba8();
+            for p in image8bit.pixels_mut() {
+                if p[0] == 255 && p[1] == 255 && p[2] == 255 {
+                    p[3] = 0;
+                }
             }
+            *image = DynamicImage::ImageRgba8(image8bit);
         }
-        *image = DynamicImage::ImageRgba8(image8bit);
-    } else if color_info.bit_depth == 16 {
-        let mut image16bit = image.to_rgba16();
-        for p in image16bit.pixels_mut() {
-            if p[0] == 255 && p[1] == 255 && p[2] == 255 {
-                p[3] = 0;
+
+        B16 => {
+            let mut image16bit = image.to_rgba16();
+            for p in image16bit.pixels_mut() {
+                if p[0] == 255 && p[1] == 255 && p[2] == 255 {
+                    p[3] = 0;
+                }
             }
+            *image = DynamicImage::ImageRgba16(image16bit);
         }
-        *image = DynamicImage::ImageRgba16(image16bit);
-    } else {
-        let mut image32bit = image.to_rgba32f();
-        for p in image32bit.pixels_mut() {
-            if p[0] == 255.0 && p[1] == 255.0 && p[2] == 255.0 {
-                p[3] = 0.0;
+
+        B32 => {
+            let mut image32bit = image.to_rgba32f();
+            for p in image32bit.pixels_mut() {
+                if p[0] == 255.0 && p[1] == 255.0 && p[2] == 255.0 {
+                    p[3] = 0.0;
+                }
             }
+            *image = DynamicImage::ImageRgba32F(image32bit);
         }
-        *image = DynamicImage::ImageRgba32F(image32bit);
     }
 }


### PR DESCRIPTION
# Introduction

The crate [image](https://docs.rs/image/latest/image/index.html) provides a few extended color types which can be used when converting images. 
I aim to add the functionality to encode and decode images to and from these extended color types.

## Goals 

- [ ] Get types from arguments
- [ ] Maybe deprecate ColorInfo in favor of using the extended color types instead
- [ ] Expand BitDepths